### PR TITLE
Migrate audio content to Bandcamp

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -33,16 +33,6 @@ a:hover, a:visited, a:link, a:active {
     color: #000000;
 }
 
-.player-surround {
-	width: 620px;
-	height: 30px;
-	padding-top: 20px;
-	padding-bottom: 10px;
-	padding-left: 10px;
-	padding-right: 10px;
-	background: #d5d5d5;
-}
-
 .image-caption {
 	padding-top: 30px;
 }

--- a/index.html
+++ b/index.html
@@ -7,9 +7,7 @@ layout: default
     <p id="header-text">Henrik Lafrenz im Gespr&auml;ch mit Deert Lafrenz. Circa 60 Minuten Audiomaterial, unterteilt in sieben Episoden. Bebildert mit 16 historischen Fotos.</p>
 
 	<h3 class="chapter">Teil 1/7</h3>
-	<div class="player-surround">
-		<iframe width="100%" height="20" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/196776781%3Fsecret_token%3Ds-M4RoG&amp;color=00aabb&amp;inverse=false&amp;auto_play=false&amp;show_user=true"></iframe>
-	</div>
+	<iframe style="border: 0; width: 100%; height: 42px;" src="https://bandcamp.com/EmbeddedPlayer/album=2125650861/size=small/bgcol=ffffff/linkcol=0687f5/artwork=none/track=1137168433/transparent=true/" seamless><a href="http://henriklafrenz.bandcamp.com/album/der-deichgraf-peter-lafrenz">Der Deichgraf Peter Lafrenz by Deert Lafrenz &amp; Henrik Lafrenz</a></iframe>
 	<div class="image-caption">
 		<a href="img/ch1/ch1_1.jpg" target="_blank">
 			<img src="img/ch1/ch1_1_th@2x.jpg" width="640" height="423" alt="Die Goldene Hochzeit">
@@ -18,9 +16,7 @@ layout: default
 	</div>
 
 	<h3 class="chapter">Teil 2/7</h3>
-	<div class="player-surround">
-		<iframe width="100%" height="20" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/196776782%3Fsecret_token%3Ds-BxgPW&amp;color=00aabb&amp;inverse=false&amp;auto_play=false&amp;show_user=true"></iframe>
-	</div>
+	<iframe style="border: 0; width: 100%; height: 42px;" src="https://bandcamp.com/EmbeddedPlayer/album=2125650861/size=small/bgcol=ffffff/linkcol=0687f5/artwork=none/track=1853855913/transparent=true/" seamless><a href="http://henriklafrenz.bandcamp.com/album/der-deichgraf-peter-lafrenz">Der Deichgraf Peter Lafrenz by Deert Lafrenz &amp; Henrik Lafrenz</a></iframe>
 	<div class="image-caption">
 		<a href="img/ch2/ch2_1.jpg" target="_blank">
 			<img src="img/ch2/ch2_1_th@2x.jpg" width="640" height="437" alt="Der Deichgraf am Schreibtisch">
@@ -30,9 +26,7 @@ layout: default
 	</div>
 
 	<h3 class="chapter">Teil 3/7</h3>
-	<div class="player-surround">
-		<iframe width="100%" height="20" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/196776783%3Fsecret_token%3Ds-BDyRQ&amp;color=00aabb&amp;inverse=false&amp;auto_play=false&amp;show_user=true"></iframe>
-	</div>
+	<iframe style="border: 0; width: 100%; height: 42px;" src="https://bandcamp.com/EmbeddedPlayer/album=2125650861/size=small/bgcol=ffffff/linkcol=0687f5/artwork=none/track=538769685/transparent=true/" seamless><a href="http://henriklafrenz.bandcamp.com/album/der-deichgraf-peter-lafrenz">Der Deichgraf Peter Lafrenz by Deert Lafrenz &amp; Henrik Lafrenz</a></iframe>
 	<div class="image-caption">
 		<a href="img/ch3/ch3_1.jpg" target="_blank">
 			<img src="img/ch3/ch3_1_th@2x.jpg" width="600" height="794" alt="Betriebsausflug">
@@ -52,9 +46,7 @@ layout: default
 	</div>
 
 	<h3 class="chapter">Teil 4/7</h3>
-	<div class="player-surround">
-		<iframe width="100%" height="20" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/196776784%3Fsecret_token%3Ds-jvwxR&amp;color=00aabb&amp;inverse=false&amp;auto_play=false&amp;show_user=true"></iframe>
-	</div>
+	<iframe style="border: 0; width: 100%; height: 42px;" src="https://bandcamp.com/EmbeddedPlayer/album=2125650861/size=small/bgcol=ffffff/linkcol=0687f5/artwork=none/track=2252622715/transparent=true/" seamless><a href="http://henriklafrenz.bandcamp.com/album/der-deichgraf-peter-lafrenz">Der Deichgraf Peter Lafrenz by Deert Lafrenz &amp; Henrik Lafrenz</a></iframe>
 	<div class="image-caption">
 		<a href="img/ch4/ch4_1.jpg" target="_blank">
 			<img src="img/ch4/ch4_1_th@2x.jpg" width="640" height="438" alt="Der Deichgraf am Theodoliten"></a>
@@ -78,9 +70,7 @@ layout: default
 	</div>
 
 	<h3 class="chapter">Teil 5/7</h3>
-	<div class="player-surround">
-		<iframe width="100%" height="20" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/196776785%3Fsecret_token%3Ds-RfRSe&amp;color=00aabb&amp;inverse=false&amp;auto_play=false&amp;show_user=true"></iframe>
-	</div>
+	<iframe style="border: 0; width: 100%; height: 42px;" src="https://bandcamp.com/EmbeddedPlayer/album=2125650861/size=small/bgcol=ffffff/linkcol=0687f5/artwork=none/track=897462007/transparent=true/" seamless><a href="http://henriklafrenz.bandcamp.com/album/der-deichgraf-peter-lafrenz">Der Deichgraf Peter Lafrenz by Deert Lafrenz &amp; Henrik Lafrenz</a></iframe>
 	<div class="image-caption">
 		<a href="img/ch5/ch5_1.jpg" target="_blank">
 			<img src="img/ch5/ch5_1_th@2x.jpg" width="640" height="471" alt="Hamburge Hallig - Gruppenfoto">
@@ -125,9 +115,7 @@ layout: default
 	</div>
 
 	<h3 class="chapter">Teil 6/7</h3>
-	<div class="player-surround">
-		<iframe width="100%" height="20" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/196776786%3Fsecret_token%3Ds-ywn5Z&amp;color=00aabb&amp;inverse=false&amp;auto_play=false&amp;show_user=true"></iframe>
-	</div>
+	<iframe style="border: 0; width: 100%; height: 42px;" src="https://bandcamp.com/EmbeddedPlayer/album=2125650861/size=small/bgcol=ffffff/linkcol=0687f5/artwork=none/track=100988255/transparent=true/" seamless><a href="http://henriklafrenz.bandcamp.com/album/der-deichgraf-peter-lafrenz">Der Deichgraf Peter Lafrenz by Deert Lafrenz &amp; Henrik Lafrenz</a></iframe>
 	<div class="image-caption">
 		<a href="img/ch6/ch6_1.jpg" target="_blank">
 			<img src="img/ch6/ch6_1_th@2x.jpg" width="640" height="441" alt="Trischendamm I">
@@ -158,9 +146,7 @@ layout: default
 	</div>
 
 	<h3 class="chapter">Teil 7/7</h3>
-	<div class="player-surround">
-		<iframe width="100%" height="20" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/196776787%3Fsecret_token%3Ds-UzrAZ&amp;color=00aabb&amp;inverse=false&amp;auto_play=false&amp;show_user=true"></iframe>
-	</div>
+	<iframe style="border: 0; width: 100%; height: 42px;" src="https://bandcamp.com/EmbeddedPlayer/album=2125650861/size=small/bgcol=ffffff/linkcol=0687f5/artwork=none/track=3962991006/transparent=true/" seamless><a href="http://henriklafrenz.bandcamp.com/album/der-deichgraf-peter-lafrenz">Der Deichgraf Peter Lafrenz by Deert Lafrenz &amp; Henrik Lafrenz</a></iframe>
 	<div class="image-caption">
 		<a href="img/ch7/ch7_1.jpg" target="_blank">
 			<img src="img/ch7/ch7_1_th@2x.jpg" width="600" height="630" alt="Eckernf&ouml;rde I">


### PR DESCRIPTION
Replace Soundcloud players with Bandcamp players. The new site at Bandcamp is:
https://henriklafrenz.bandcamp.com/